### PR TITLE
Add support for multiple success status codes for toolbar display

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -50,6 +50,7 @@ class DebugToolbarExtension(object):
         os.path.join(os.path.dirname(__file__), 'static'))
 
     _redirect_codes = [301, 302, 303, 304]
+    _success_codes = [200, 201]
 
     def __init__(self, app=None):
         self.app = app
@@ -205,7 +206,7 @@ class DebugToolbarExtension(object):
 
         # If the http response code is 200 then we process to add the
         # toolbar to the returned html response.
-        if not (response.status_code == 200 and
+        if not (response.status_code in self._success_codes and
                 response.is_sequence and
                 response.headers['content-type'].startswith('text/html')):
             return response

--- a/flask_debugtoolbar/static/css/toolbar.css
+++ b/flask_debugtoolbar/static/css/toolbar.css
@@ -167,6 +167,7 @@
   left:0px;
   background-color:#eee;
   color:#666;
+  overflow:auto;
   z-index:100000000;
 }
 

--- a/flask_debugtoolbar/templates/base.html
+++ b/flask_debugtoolbar/templates/base.html
@@ -35,7 +35,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div style="display:none;" id="flDebugToolbarHandle">
+  <div role="navigation" style="display:none;" id="flDebugToolbarHandle">
     <a title="Show Toolbar" id="flDebugShowToolBarButton" href="#">&laquo;</a>
   </div>
   {% for panel in panels %}

--- a/flask_debugtoolbar/templates/base.html
+++ b/flask_debugtoolbar/templates/base.html
@@ -1,4 +1,4 @@
-<div id="flDebug" style="display:none;">
+<div role="navigation" id="flDebug" style="display:none;">
   <script type="text/javascript">var DEBUG_TOOLBAR_STATIC_PATH = '{{ static_path }}'</script>
   <script type="text/javascript" src="{{ static_path }}js/jquery.js"></script>
   <script type="text/javascript" src="{{ static_path }}js/jquery.tablesorter.js"></script>
@@ -35,7 +35,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div role="navigation" style="display:none;" id="flDebugToolbarHandle">
+  <div style="display:none;" id="flDebugToolbarHandle">
     <a title="Show Toolbar" id="flDebugShowToolBarButton" href="#">&laquo;</a>
   </div>
   {% for panel in panels %}


### PR DESCRIPTION
We encountered a scenario where we need the toolbar to be displayed on additional status codes, so our team added functionality which enables the toolbar display on multiple success status codes. 


