### PR TITLE
Remove deprecated Jinja with_ extension for Jinja 3.0 (related to Flask 2.0)

### DIFF
--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -3,6 +3,7 @@ import warnings
 
 from flask import Blueprint, current_app, request, g, send_from_directory, url_for
 from flask.globals import _request_ctx_stack
+from jinja2 import __version__ as __jinja_version__
 from jinja2 import Environment, PackageLoader
 from werkzeug.urls import url_quote_plus
 
@@ -54,12 +55,16 @@ class DebugToolbarExtension(object):
     def __init__(self, app=None):
         self.app = app
         self.debug_toolbars = {}
+        jinja_extensions = ['jinja2.ext.i18n']
+
+        if __jinja_version__[0] == '2':
+            jinja_extensions.append('jinja2.ext.with_')
 
         # Configure jinja for the internal templates and add url rules
         # for static data
         self.jinja_env = Environment(
             autoescape=True,
-            extensions=['jinja2.ext.i18n', 'jinja2.ext.with_'],
+            extensions=jinja_extensions,
             loader=PackageLoader(__name__, 'templates'))
         self.jinja_env.filters['urlencode'] = url_quote_plus
         self.jinja_env.filters['printable'] = _printable


### PR DESCRIPTION
I ran into this deprecation warning when updating a project to use Flask 2.0. Jinja 3.0 throws a deprecation warning that this will be removed in 3.1 because it's built into Jinja now without needing an extension.

Here's the specific warning:

```
python3.9/site-packages/jinja2/environment.py:119: DeprecationWarning: The 'with' extension is
deprecated and will be removed in Jinja 3.1. This is built in now.
    result[extension.identifier] = extension(environment)
```

But since folks might want to use Jinja 2 for a while this PR supports both versions by only using the `with_` extension with Jinja 2.

More details about this deprecation can be found here: https://github.com/pallets/jinja/issues/1429