### PR TITLE
Permit scrolling for content panels

### DIFF
--- a/src/flask_debugtoolbar/static/css/toolbar.css
+++ b/src/flask_debugtoolbar/static/css/toolbar.css
@@ -167,6 +167,7 @@
   left:0px;
   background-color:#eee;
   color:#666;
+  overflow: auto;
   z-index:100000000;
 }
 


### PR DESCRIPTION
When the list of content in a panel exceed the vertical space of the browser window, there isn't a way to see the overflow. This is a small CSS change to allow overflow scrolling on the panels.