### PR TITLE
Add ARIA role to toolbar for accessibility improvement

### DIFF
--- a/src/flask_debugtoolbar/templates/base.html
+++ b/src/flask_debugtoolbar/templates/base.html
@@ -1,4 +1,4 @@
-<div id="flDebug" style="display:none;">
+<div id="flDebug" style="display:none;" role="navigation">
   <script type="text/javascript">var DEBUG_TOOLBAR_STATIC_PATH = '{{ static_path }}'</script>
   <script type="text/javascript" src="{{ static_path }}js/jquery.js"></script>
   <script type="text/javascript" src="{{ static_path }}js/jquery.tablesorter.js"></script>


### PR DESCRIPTION
Change to improve accessibility compliance, for example useful when a developer is using a screen reader. Using the ARIA role attribute is a HTML4 compatible way of accomplishing this.

For reference: https://dequeuniversity.com/rules/axe/4.3/region