### PR TITLE
Submodule to use https protocol after unencrypted git proto deprecated

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes.git


### PR DESCRIPTION
Change to use https: for submodule as GitHub has disabled use of unencrypted git: protocol. 

Ref: https://github.blog/2021-09-01-improving-git-protocol-security-github/