### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/flask_debugtoolbar/panels/profiler.py
+++ b/src/flask_debugtoolbar/panels/profiler.py
@@ -73,7 +73,7 @@ class ProfilerDebugPanel(DebugPanel):
                 # Cumulative time
                 current['cumtime'] = info[3] * 1000
 
-                # Quotient of the cumulative time divded by the number of
+                # Quotient of the cumulative time divided by the number of
                 # primitive calls.
                 if info[0]:
                     current['percall_cum'] = info[3] * 1000 / info[0]

--- a/src/flask_debugtoolbar/static/codemirror/mode/rst/rst.js
+++ b/src/flask_debugtoolbar/static/codemirror/mode/rst/rst.js
@@ -183,7 +183,7 @@ CodeMirror.defineMode('rst', function(config, options) {
                     setState(state, inline, {
                         ch: orig,               // inline() has to know what to search for
                         wide: wide,             // are we looking for `ch` or `chch`
-                        prev: null,             // terminator must not be preceeded with whitespace
+                        prev: null,             // terminator must not be preceded with whitespace
                         token: token            // I don't want to recompute this all the time
                     });
 

--- a/src/flask_debugtoolbar/static/codemirror/mode/xquery/xquery.js
+++ b/src/flask_debugtoolbar/static/codemirror/mode/xquery/xquery.js
@@ -26,7 +26,7 @@ CodeMirror.defineMode("xquery", function(config, parserConfig) {
   // function. Each keyword is a property of the keywords object whose
   // value is {type: atype, style: astyle}
   var keywords = function(){
-    // conveinence functions used to build keywords object
+    // convenience functions used to build keywords object
     function kw(type) {return {type: type, style: "keyword"};}
     var A = kw("keyword a")
       , B = kw("keyword b")

--- a/src/flask_debugtoolbar/static/js/jquery.tablesorter.js
+++ b/src/flask_debugtoolbar/static/js/jquery.tablesorter.js
@@ -13,13 +13,13 @@
  */
 /**
  * 
- * @description Create a sortable table with multi-column sorting capabilitys
+ * @description Create a sortable table with multi-column sorting capabilities
  * 
  * @example $('table').tablesorter();
  * @desc Create a simple tablesorter interface.
  * 
  * @example $('table').tablesorter({ sortList:[[0,0],[1,0]] });
- * @desc Create a tablesorter interface and sort on the first and secound column column headers.
+ * @desc Create a tablesorter interface and sort on the first and second column column headers.
  * 
  * @example $('table').tablesorter({ headers: { 0: { sorter: false}, 1: {sorter: false} } });
  *          
@@ -49,7 +49,7 @@
  *         to sortable tr elements in the thead on a descending sort. Default
  *         value: "headerSortDown"
  * 
- * @option String sortInitialOrder (optional) A string of the inital sorting
+ * @option String sortInitialOrder (optional) A string of the initial sorting
  *         order can be asc or desc. Default value: "asc"
  * 
  * @option String sortMultisortKey (optional) A string of the multi-column sort
@@ -90,7 +90,7 @@
  *         Default value: true
  * 
  * @option Boolean debug (optional) Boolean flag indicating if tablesorter
- *         should display debuging information usefull for development.
+ *         should display debugging information usefull for development.
  * 
  * @type jQuery
  * 
@@ -134,7 +134,7 @@
                 debug: false
             };
 
-            /* debuging utils */
+            /* debugging utils */
 
             function benchmark(s, d) {
                 log(s + "," + (new Date().getTime() - d.getTime()) + "ms");


### PR DESCRIPTION
There are small typos in:
- src/flask_debugtoolbar/panels/profiler.py
- src/flask_debugtoolbar/static/codemirror/mode/rst/rst.js
- src/flask_debugtoolbar/static/codemirror/mode/xquery/xquery.js
- src/flask_debugtoolbar/static/js/jquery.tablesorter.js

Fixes:
- Should read `second` rather than `secound`.
- Should read `preceded` rather than `preceeded`.
- Should read `initial` rather than `inital`.
- Should read `divided` rather than `divded`.
- Should read `debugging` rather than `debuging`.
- Should read `convenience` rather than `conveinence`.
- Should read `capabilities` rather than `capabilitys`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md