### PR TITLE
Fixed scrollbar issue due to incorrect classname

### DIFF
--- a/src/flask_debugtoolbar/static/css/toolbar.css
+++ b/src/flask_debugtoolbar/static/css/toolbar.css
@@ -201,11 +201,11 @@
   padding:0 0 0 20px;
 }
 
-#flDebug .flDebugPanelContent .scroll {
+#flDebug .flDebugPanelContent .flDebugScroll {
   height:100%;
   overflow:auto;
   display:block;
-  padding:0 10px 0 0;
+  padding:0 10px 10px 0;
 }
 
 #flDebug h3 {

--- a/src/flask_debugtoolbar/templates/panels/sqlalchemy_select.html
+++ b/src/flask_debugtoolbar/templates/panels/sqlalchemy_select.html
@@ -3,7 +3,7 @@
   <h3>SQL Details</h3>
 </div>
 <div class="flDebugPanelContent">
-  <div class="scroll">
+  <div class="flDebugScroll">
     <dl>
       <dt>Executed SQL</dt>
       <dd>{{ sql }}</dd>


### PR DESCRIPTION
Fixes #181 where the scrollbar would not show on any page other than the `sqlalchemy_select.html` template. The scroll classname is now properly named and applied throughout all panel templates as `flDebugScroll`. I've also added a 10px bottom padding to show the end of the inner panel (for aesthetics sake).